### PR TITLE
Rename pallet and adjust timing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,7 +177,7 @@ void iceLamp()
 
 void fireLamp() 
 {
-    CRGBPalette16 fire = pFire;
+    CRGBPalette16 firePallete = pFire;
     bool flipDirection = true;
 
     uint8_t brightnessSine1 = beatsin8(1, 64, 180, 0, 0);
@@ -185,16 +185,10 @@ void fireLamp()
     uint8_t brightnessSine3 = beatsin8(11, 32, 200, 0, 0);
     uint8_t brightness = (brightnessSine1 + brightnessSine2 + brightnessSine3) / 3;
 
-    // for(uint8_t i = 0; i < NUM_LEDS; i++){
-    //     // leds[i] = ColorFromPalette(fire, colourIndex[i]);
-    //     leds[i] = CRGB(0, 0, 0);
-    // }
- 
-
-    fill_palette(leds, NUM_LEDS, paletteIndex, 255 / NUM_LEDS, fire, brightness, LINEARBLEND);    
+    fill_palette(leds, NUM_LEDS, paletteIndex, 255 / NUM_LEDS, firePallete, brightness, LINEARBLEND);    
     // add_glitter();
 
-    EVERY_N_MILLISECONDS(150){
+    EVERY_N_MILLISECONDS(200){
         paletteIndex++;
     }
 


### PR DESCRIPTION
# Description

This change will adjust the primary timings of the main crystal animation, increase base luminance of both backboard arrays and rename the primary effect palette.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Changes have not been tested.  Changes will be tested en masse when hardware is available to flash.



## Tested With

- [ ] Production hardware
- [x] Prototype hardware (same target)
- [ ] Other target

**Test Configuration**:
* Firmware version: 0.0.1
* Hardware: ESP32
* Toolchain: PlatformIO
* SDK: Espressif

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

